### PR TITLE
fix: typo in filament_load

### DIFF
--- a/filament.cfg
+++ b/filament.cfg
@@ -42,7 +42,7 @@ gcode:
     G1 Z{pos.z} F{user.speed.z_hop} 
     M83                                                   ; set extruder to relative
     G1 E{user.filament.load_distance} F{user.speed.load}  ; quickly load filament
-    {% if user.hw.runout.typet == 'motion' %}
+    {% if user.hw.runout.type == 'motion' %}
       _PRINT_AR T="RUNOUT Motion Sensor Enable: true"
       SET_FILAMENT_SENSOR SENSOR=runout ENABLE=1
     {% endif %}


### PR DESCRIPTION
Small Typo in FILAMENT_LOAD.
The sensor is not activated after loading the filament.