### PR TITLE
fixed typo in jinja template code

### DIFF
--- a/macro.cfg
+++ b/macro.cfg
@@ -272,7 +272,7 @@ gcode:
   {% if printer['gcode_macro PRINT_START'].var.redo_qgl|lower == 'true' %}
     _PRINT_AR T="QGL forced by PRINT_START"
     QUAD_GANTRY_LEVEL PARK=false HOME=false
-  {% elif printer.quad_gantry_level.applied|lower == 'false' %} %} 
+  {% elif printer.quad_gantry_level.applied|lower == 'false' %}
     _PRINT_AR T="QGL not executed yet"
     QUAD_GANTRY_LEVEL PARK=false HOME=false
   {% endif %}


### PR DESCRIPTION
extra '%}' in code